### PR TITLE
Form submit

### DIFF
--- a/src/forms/field-name.definer.ts
+++ b/src/forms/field-name.definer.ts
@@ -2,7 +2,7 @@ import { InGroup } from '@frontmeans/input-aspects';
 import { afterAll, consumeEvents } from '@proc7ts/fun-events';
 import { Class, Supply } from '@proc7ts/primitives';
 import { ComponentClass } from '@wesib/wesib';
-import { ComponentShare__symbol, ComponentShareRef } from '../share';
+import { componentShareLocator, ComponentShareLocator } from '../share';
 import { Field } from './field';
 import { Field$nameByKey } from './field.impl';
 import { Form } from './form';
@@ -62,7 +62,7 @@ function FormUnitName<
   return ({
     key,
     share,
-    formShare,
+    locateForm: defaultForm,
     name: defaultName,
   }) => {
 
@@ -84,7 +84,7 @@ function FormUnitName<
       fieldName = autoName;
     }
 
-    const fieldFormShare = (def.form || formShare || FormShare)[ComponentShare__symbol];
+    const locateForm = componentShareLocator(def.form || defaultForm, { share: FormShare });
 
     return {
       componentDef: {
@@ -92,7 +92,7 @@ function FormUnitName<
           setup.whenComponent(context => {
             afterAll({
               unit: context.get(share),
-              form: fieldFormShare.valueFor(context),
+              form: locateForm(context),
             }).do(
                 consumeEvents(({ unit: [field], form: [form] }): Supply | undefined => {
                   if (!form || !field) {
@@ -123,11 +123,11 @@ export interface FieldNameDef {
   /**
    * A form to add the field to.
    *
-   * This is a reference to the form share.
+   * This is a shared form locator.
    *
    * Either {@link SharedFieldDef.form predefined}, or {@link FieldShare default} form share is used when omitted.
    */
-  readonly form?: ComponentShareRef<Form>;
+  readonly form?: ComponentShareLocator<Form>;
 
   /**
    * Field name.

--- a/src/forms/index.ts
+++ b/src/forms/index.ts
@@ -10,6 +10,7 @@ export * from './form.share';
 export * from './form-preset';
 export * from './form-unit';
 export * from './presets';
+export * from './on-submit.decorator';
 export * from './shared-field.decorator';
 export * from './shared-form.decorator';
 export * from './shared-form-unit.decorator';

--- a/src/forms/on-submit.decorator.spec.ts
+++ b/src/forms/on-submit.decorator.spec.ts
@@ -1,0 +1,98 @@
+import { inFormElement, InGroup, inGroup } from '@frontmeans/input-aspects';
+import { afterThe } from '@proc7ts/fun-events';
+import { noop } from '@proc7ts/primitives';
+import { Component, ComponentMount } from '@wesib/wesib';
+import { testDefinition } from '../spec/test-element';
+import { Form } from './form';
+import { OnSubmit, OnSubmitDef } from './on-submit.decorator';
+import { SharedForm, SharedFormDef } from './shared-form.decorator';
+
+describe('forms', () => {
+  describe('@OnSubmit', () => {
+
+    interface TestData {
+      property?: string;
+    }
+
+    let element: Element;
+    let formElement: HTMLFormElement;
+
+    beforeEach(() => {
+      element = document.body.appendChild(document.createElement('custom-element'));
+      formElement = element.appendChild(document.createElement('form'));
+    });
+    afterEach(() => {
+      element.remove();
+    });
+
+    it('calls decorated method on submit', async () => {
+
+      const onSubmit = jest.fn();
+
+      await bootstrap(onSubmit);
+
+      formElement.requestSubmit();
+      expect(onSubmit).toHaveBeenCalledWith(
+          expect.objectContaining({
+            control: expect.any(InGroup),
+            element: expect.objectContaining({ element: expect.objectContaining({ tagName: 'FORM' }) }),
+          }),
+          expect.objectContaining({
+            type: 'submit',
+          }),
+      );
+    });
+    it('cancels default event handler by default', async () => {
+      await bootstrap(noop);
+
+      const submit = new Event('submit', { cancelable: true });
+
+      expect(formElement.dispatchEvent(submit)).toBe(false);
+    });
+    it('does not cancel default event handler when `cancel` is `false`', async () => {
+      await bootstrap(noop, { cancel: false });
+
+      const submit = new Event('submit', { cancelable: true });
+
+      expect(formElement.dispatchEvent(submit)).toBe(true);
+    });
+    it('does not submit when there is no form', async () => {
+
+      const defaultSubmit = jest.fn(e => e.preventDefault());
+
+      formElement.addEventListener('submit', defaultSubmit);
+
+      const onSubmit = jest.fn();
+
+      await bootstrap(onSubmit, { form: () => afterThe() });
+      formElement.requestSubmit();
+      expect(defaultSubmit).toHaveBeenLastCalledWith(expect.objectContaining({ type: 'submit' }));
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    async function bootstrap(
+        onSubmit: (form: Form<TestData>, event: Event) => void,
+        def?: OnSubmitDef,
+        formDef?: SharedFormDef<Form<TestData>>,
+    ): Promise<ComponentMount> {
+
+      @Component('custom-element')
+      class TestElement {
+
+        @SharedForm(formDef)
+        form = Form.by<TestData>(
+            opts => inGroup({}, opts),
+            opts => inFormElement(formElement, opts),
+        );
+
+        @OnSubmit(def)
+        readonly onSubmit = onSubmit;
+
+      }
+
+      const defContext = await testDefinition(TestElement);
+
+      return defContext.mountTo(element);
+    }
+  });
+});

--- a/src/forms/on-submit.decorator.ts
+++ b/src/forms/on-submit.decorator.ts
@@ -1,0 +1,85 @@
+import { handleDomEvents } from '@frontmeans/dom-events';
+import { consumeEvents } from '@proc7ts/fun-events';
+import { Class } from '@proc7ts/primitives';
+import { ComponentClass, ComponentContext, ComponentProperty, ComponentPropertyDecorator } from '@wesib/wesib';
+import { componentShareLocator, ComponentShareLocator } from '../share';
+import { Form } from './form';
+import { FormShare } from './form.share';
+
+/**
+ * Creates a decorator for component method to call on input form submit.
+ *
+ * The decorated method accepts a {@link Form form} to submit and submit event as parameters.
+ *
+ * @typeParam TModel - Submitted model type.
+ * @typeParam TElt - A type of HTML form element.
+ * @typeParam TClass - A type of decorated component class.
+ * @param def - Submit handler definition.
+ *
+ * @returns New component property decorator.
+ */
+export function OnSubmit<TModel = any, TElt extends HTMLElement = HTMLElement, T extends ComponentClass = Class>(
+    def: OnSubmitDef<TModel, TElt> = {},
+): ComponentPropertyDecorator<(form: Form<TModel, TElt>, event: Event) => void, T> {
+
+  const { form: formRef = FormShare, cancel = true } = def;
+  const locateForm = componentShareLocator(formRef, { share: FormShare, self: true });
+
+  return ComponentProperty(({ get }) => ({
+    componentDef: {
+      define(defContext) {
+        defContext.whenComponent(context => {
+          context.whenConnected(() => {
+
+            const { component } = context;
+
+            locateForm(context).do(
+                consumeEvents((form?: Form<TModel, TElt>, _sharer?: ComponentContext) => {
+                  if (!form) {
+                    return;
+                  }
+
+                  let onSubmit = form.element.events.on('submit');
+
+                  if (cancel) {
+                    onSubmit = onSubmit.do(
+                        handleDomEvents(false),
+                    );
+                  }
+
+                  return onSubmit(
+                      event => get(component).call(component, form, event),
+                  );
+                }),
+            ).needs(context);
+          });
+        });
+      },
+    },
+  }));
+}
+
+/**
+ * Form submit handler definition.
+ *
+ * Configures {@link OnSubmit @OnSubmit} component property decorator.
+ */
+export interface OnSubmitDef<TModel = any, TElt extends HTMLElement = HTMLElement> {
+
+  /**
+   * A form to submit.
+   *
+   * This is a shared form locator.
+   *
+   * A {@link FieldShare default} form share is used when omitted.
+   */
+  readonly form?: ComponentShareLocator<Form<TModel, TElt>>;
+
+  /**
+   * Whether to cancel default submit handler.
+   *
+   * `true` by default.
+   */
+  readonly cancel?: boolean;
+
+}

--- a/src/forms/shared-field.decorator.ts
+++ b/src/forms/shared-field.decorator.ts
@@ -1,6 +1,13 @@
 import { Class } from '@proc7ts/primitives';
 import { ComponentClass } from '@wesib/wesib';
-import { ComponentShare, ComponentShare__symbol, ComponentShareDecorator, ComponentShareRef, Shared } from '../share';
+import {
+  ComponentShare,
+  ComponentShareDecorator,
+  componentShareLocator,
+  ComponentShareLocator,
+  ComponentShareRef,
+  Shared,
+} from '../share';
 import { Field } from './field';
 import { FieldName } from './field-name.definer';
 import { Field$name } from './field.impl';
@@ -71,9 +78,9 @@ export function SharedField<
 
   const {
     share = FieldShare as ComponentShareRef<any> as ComponentShareRef<TField>,
-    form: formShareRef = FormShare,
+    form: formLocator,
   } = def;
-  const formShare: ComponentShare<Form<any, any>> = formShareRef[ComponentShare__symbol];
+  const locateForm = componentShareLocator(formLocator, { share: FormShare });
 
   return SharedFormUnit<TField, TValue, Field.Controls<TValue>, TClass>(
       share,
@@ -81,7 +88,7 @@ export function SharedField<
           descriptor: Shared.Descriptor<TField, TClass>,
       ) => definer({
         ...descriptor,
-        formShare,
+        locateForm,
         name: Field$name(descriptor.key, fieldName),
       })),
   );
@@ -103,11 +110,11 @@ export interface SharedFieldDef<TField extends Field<TValue>, TValue = Field.Val
   /**
    * A form to add the field to.
    *
-   * This is a reference to the form share.
+   * This is shared form locator.
    *
    * The {@link FieldShare default form share} is used when omitted.
    */
-  readonly form?: ComponentShareRef<Form>;
+  readonly form?: ComponentShareLocator<Form>;
 
   /**
    * Field name.
@@ -145,12 +152,12 @@ export namespace SharedField {
     readonly share: ComponentShare<TField>;
 
     /**
-     * Predefined share of the form to add the field to, or `undefined` when unknown.
+     * Predefined share locator of the form to add the field to.
      */
-    readonly formShare: ComponentShare<Form<any, any>>;
+    readonly locateForm: ComponentShareLocator<Form<any, any>>;
 
     /**
-     * Predefined field name, or `null`/`undefined` when the field is not to be added to the {@link formShare form}.
+     * Predefined field name, or `null`/`undefined` when the field is not to be added to the {@link locateForm form}.
      */
     readonly name: string | null;
 

--- a/src/forms/shared-field.decorator.ts
+++ b/src/forms/shared-field.decorator.ts
@@ -152,9 +152,9 @@ export namespace SharedField {
     readonly share: ComponentShare<TField>;
 
     /**
-     * Predefined share locator of the form to add the field to.
+     * Predefined locator function of the form to add the field to.
      */
-    readonly locateForm: ComponentShareLocator<Form<any, any>>;
+    readonly locateForm: ComponentShareLocator.Fn<Form<any, any>>;
 
     /**
      * Predefined field name, or `null`/`undefined` when the field is not to be added to the {@link locateForm form}.

--- a/src/forms/shared-form-unit.decorator.ts
+++ b/src/forms/shared-form-unit.decorator.ts
@@ -47,9 +47,9 @@ export namespace SharedFormUnit {
       extends Shared.Descriptor<TUnit, TClass> {
 
     /**
-     * Predefined share locator of the form to add the unit to, or `undefined` when unknown.
+     * Predefined locator function of the form to add the unit to, or `undefined` when unknown.
      */
-    readonly locateForm?: ComponentShareLocator<Form<any, any>>;
+    readonly locateForm?: ComponentShareLocator.Fn<Form<any, any>>;
 
     /**
      * Predefined unit name, or `null`/`undefined` when the unit is not to be added to the {@link locateForm form}.

--- a/src/forms/shared-form-unit.decorator.ts
+++ b/src/forms/shared-form-unit.decorator.ts
@@ -1,6 +1,6 @@
 import { Class } from '@proc7ts/primitives';
 import { ComponentClass } from '@wesib/wesib';
-import { ComponentShare, ComponentShareDecorator, ComponentShareRef, Shared } from '../share';
+import { ComponentShareDecorator, ComponentShareLocator, ComponentShareRef, Shared } from '../share';
 import { Form } from './form';
 import { FormUnit } from './form-unit';
 
@@ -47,12 +47,12 @@ export namespace SharedFormUnit {
       extends Shared.Descriptor<TUnit, TClass> {
 
     /**
-     * Predefined share of the form to add the unit to, or `undefined` when unknown.
+     * Predefined share locator of the form to add the unit to, or `undefined` when unknown.
      */
-    readonly formShare?: ComponentShare<Form<any, any>>;
+    readonly locateForm?: ComponentShareLocator<Form<any, any>>;
 
     /**
-     * Predefined unit name, or `null`/`undefined` when the unit is not to be added to the {@link formShare form}.
+     * Predefined unit name, or `null`/`undefined` when the unit is not to be added to the {@link locateForm form}.
      */
     readonly name?: string | null;
 

--- a/src/share/component-share-locator.spec.ts
+++ b/src/share/component-share-locator.spec.ts
@@ -1,0 +1,170 @@
+import { afterThe } from '@proc7ts/fun-events';
+import { ComponentContext } from '@wesib/wesib';
+import { ComponentShare } from './component-share';
+import { ComponentShareLocator, componentShareLocator } from './component-share-locator';
+import { ComponentShare__symbol, ComponentShareRef } from './component-share-ref';
+
+describe('share', () => {
+  describe('componentShareLocator', () => {
+
+    let mockSharer: ComponentContext;
+    let mockConsumer: ComponentContext;
+    let mockShare: jest.Mocked<ComponentShare<string>>;
+    let shareRef: ComponentShareRef<string>;
+
+    beforeEach(() => {
+      mockSharer = { name: 'Mock sharer' } as any;
+      mockConsumer = { name: 'Mock consumer' } as any;
+      mockShare = { valueFor: jest.fn((_consumer, _options?) => afterThe('found', mockSharer)) } as
+          Partial<jest.Mocked<ComponentShare<string>>> as
+          jest.Mocked<ComponentShare<string>>;
+      shareRef = { [ComponentShare__symbol]: mockShare };
+    });
+
+    describe('by share reference', () => {
+      it('converts to function', async () => {
+
+        const locator = componentShareLocator(shareRef);
+
+        expect(await locator(mockConsumer)).toBe('found');
+        expect(mockShare.valueFor).toHaveBeenLastCalledWith(mockConsumer, { self: undefined });
+      });
+      it('falls back to default option', async () => {
+
+        const locator = componentShareLocator(shareRef, { self: true });
+
+        expect(await locator(mockConsumer)).toBe('found');
+        expect(mockShare.valueFor).toHaveBeenLastCalledWith(mockConsumer, { self: true });
+      });
+      it('respects explicit option', async () => {
+
+        const locator = componentShareLocator(shareRef, { self: true });
+
+        expect(await locator(mockConsumer, { self: false })).toBe('found');
+        expect(mockShare.valueFor).toHaveBeenLastCalledWith(mockConsumer, { self: false });
+      });
+    });
+
+    describe('by mandatory spec', () => {
+      it('converts to function', async () => {
+
+        const locator = componentShareLocator({ share: shareRef });
+
+        expect(await locator(mockConsumer)).toBe('found');
+        expect(mockShare.valueFor).toHaveBeenLastCalledWith(mockConsumer, { self: undefined });
+      });
+      it('falls back to default option', async () => {
+
+        const locator = componentShareLocator({ share: shareRef }, { self: true });
+
+        expect(await locator(mockConsumer)).toBe('found');
+        expect(mockShare.valueFor).toHaveBeenLastCalledWith(mockConsumer, { self: true });
+      });
+      it('respects explicit option', async () => {
+
+        const locator = componentShareLocator({ share: shareRef }, { self: true });
+
+        expect(await locator(mockConsumer, { self: false })).toBe('found');
+        expect(mockShare.valueFor).toHaveBeenLastCalledWith(mockConsumer, { self: false });
+      });
+      it('prefers explicit spec', async () => {
+
+        const locator = componentShareLocator({ share: shareRef, self: false }, { self: true });
+
+        expect(await locator(mockConsumer)).toBe('found');
+        expect(mockShare.valueFor).toHaveBeenLastCalledWith(mockConsumer, { self: false });
+      });
+    });
+
+    describe('by spec', () => {
+      it('converts to function', async () => {
+
+        const locator = componentShareLocator({}, { share: shareRef });
+
+        expect(await locator(mockConsumer)).toBe('found');
+        expect(mockShare.valueFor).toHaveBeenLastCalledWith(mockConsumer, { self: undefined });
+      });
+      it('falls back to default option', async () => {
+
+        const locator = componentShareLocator({}, { share: shareRef, self: true });
+
+        expect(await locator(mockConsumer)).toBe('found');
+        expect(mockShare.valueFor).toHaveBeenLastCalledWith(mockConsumer, { self: true });
+      });
+      it('respects explicit option', async () => {
+
+        const locator = componentShareLocator({}, { share: shareRef, self: true });
+
+        expect(await locator(mockConsumer, { self: false })).toBe('found');
+        expect(mockShare.valueFor).toHaveBeenLastCalledWith(mockConsumer, { self: false });
+      });
+      it('prefers explicit spec', async () => {
+
+        const locator = componentShareLocator({ self: false }, { share: shareRef, self: true });
+
+        expect(await locator(mockConsumer)).toBe('found');
+        expect(mockShare.valueFor).toHaveBeenLastCalledWith(mockConsumer, { self: false });
+      });
+    });
+
+    describe('by custom locator', () => {
+
+      let custom: jest.Mock<
+          ReturnType<ComponentShareLocator.Custom<string>>,
+          Parameters<ComponentShareLocator.Custom<string>>>;
+
+      beforeEach(() => {
+        custom = jest.fn((_consumer, _options) => afterThe('found', mockSharer));
+      });
+
+      it('converts to function', async () => {
+
+        const locator = componentShareLocator(custom);
+
+        expect(await locator(mockConsumer)).toBe('found');
+        expect(custom).toHaveBeenLastCalledWith(mockConsumer, { self: false });
+        expect(mockShare.valueFor).not.toHaveBeenCalled();
+      });
+      it('falls back to default option', async () => {
+
+        const locator = componentShareLocator(custom, { self: true });
+
+        expect(await locator(mockConsumer)).toBe('found');
+        expect(custom).toHaveBeenLastCalledWith(mockConsumer, { self: true });
+        expect(mockShare.valueFor).not.toHaveBeenCalled();
+      });
+      it('respects explicit option', async () => {
+
+        const locator = componentShareLocator(custom, { self: true });
+
+        expect(await locator(mockConsumer, { self: false })).toBe('found');
+        expect(custom).toHaveBeenLastCalledWith(mockConsumer, { self: false });
+        expect(mockShare.valueFor).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('by `null`', () => {
+      it('converts to function', async () => {
+
+        const locator = componentShareLocator(null, { share: shareRef });
+
+        expect(await locator(mockConsumer)).toBe('found');
+        expect(mockShare.valueFor).toHaveBeenLastCalledWith(mockConsumer, { self: undefined });
+      });
+      it('falls back to default option', async () => {
+
+        const locator = componentShareLocator(null, { share: shareRef, self: true });
+
+        expect(await locator(mockConsumer)).toBe('found');
+        expect(mockShare.valueFor).toHaveBeenLastCalledWith(mockConsumer, { self: true });
+      });
+      it('respects explicit option', async () => {
+
+        const locator = componentShareLocator(null, { share: shareRef, self: true });
+
+        expect(await locator(mockConsumer, { self: false })).toBe('found');
+        expect(mockShare.valueFor).toHaveBeenLastCalledWith(mockConsumer, { self: false });
+      });
+    });
+  });
+});

--- a/src/share/component-share-locator.ts
+++ b/src/share/component-share-locator.ts
@@ -1,0 +1,220 @@
+import { AfterEvent } from '@proc7ts/fun-events';
+import { ComponentContext } from '@wesib/wesib';
+import { ComponentShare__symbol, ComponentShareRef, isComponentShareRef } from './component-share-ref';
+
+/**
+ * Shared value locator.
+ *
+ * Can be one of:
+ *
+ * - component share {@link ComponentShareRef reference},
+ * - shared value locator specified {@link ComponentShareLocator.Spec},
+ * - {@link ComponentShareLocator.CustomWithFallback custom} shared value locator, or
+ * - `null`/`undefined` to locate a fallback share.
+ *
+ * A {@link componentShareLocator} function can be used to convert arbitrary locator to a function.
+ *
+ * @typeParam T - Shared value type.
+ */
+export type ComponentShareLocator<T> =
+    | ComponentShareRef<T>
+    | ComponentShareLocator.Spec<T>
+    | ComponentShareLocator.CustomWithFallback<T>
+    | null
+    | undefined;
+
+/**
+ * Converts mandatory shared value locator to locator function.
+ *
+ * @typeParam T - Shared value type.
+ * @param locator - Shared value locator to convert.
+ * @param defaultOptions - Default shared value locator options.
+ *
+ * @returns Shared value locator function.
+ */
+export function componentShareLocator<T>(
+    locator: ComponentShareLocator.Mandatory<T>,
+    defaultOptions?: ComponentShareLocator.Options,
+): ComponentShareLocator.Fn<T>;
+
+/**
+ * Converts arbitrary shared value locator to locator function.
+ *
+ * @typeParam T - Shared value type.
+ * @param locator - Shared value locator to convert.
+ * @param defaultSpec - Default shared value locator specifier including fallback share reference.
+ *
+ * @returns Shared value locator function.
+ */
+export function componentShareLocator<T>(
+    locator: ComponentShareLocator<T>,
+    defaultSpec: ComponentShareLocator.MandatorySpec<T>,
+): ComponentShareLocator.Fn<T>;
+
+export function componentShareLocator<T>(
+    locator:
+        | ComponentShareRef<T>
+        | Partial<ComponentShareLocator.MandatorySpec<T>>
+        | ComponentShareLocator.CustomWithFallback<T>
+        | null
+        | undefined,
+    defaultSpec: ComponentShareLocator.Spec<T> = {},
+): ComponentShareLocator.Fn<T> {
+  if (isComponentShareRef(locator)) {
+
+    const share = locator[ComponentShare__symbol];
+
+    return (consumer, options = {}) => {
+
+      const { self = defaultSpec.self } = options;
+
+      return share.valueFor(consumer, { self });
+    };
+  }
+
+  if (typeof locator === 'function') {
+
+    const { self: selfByDefault = false, share: shareByDefault } = defaultSpec;
+
+    return (consumer, options = {}) => {
+
+      const { share = shareByDefault!, self = selfByDefault } = options;
+
+      return locator(consumer, { share, self });
+    };
+  }
+
+  const { share: shareRef = defaultSpec.share!, self: selfByDefault = defaultSpec.self } = locator || {};
+  const share = shareRef[ComponentShare__symbol];
+
+  return (consumer, options = {}) => {
+
+    const { self = selfByDefault } = options;
+
+    return share.valueFor(consumer, { self });
+  };
+}
+
+export namespace ComponentShareLocator {
+
+  /**
+   * Mandatory shared value locator.
+   *
+   * Can be one of:
+   *
+   * - component share {@link ComponentShareRef reference},
+   * - shared value locator specified {@link ComponentShareLocator.Spec}, or
+   * - {@link ComponentShareLocator.Custom custom} shared value locator.
+   *
+   * A {@link componentShareLocator} function can be used to convert arbitrary locator to a function.
+   *
+   * @typeParam T - Shared value type.
+   */
+  export type Mandatory<T> =
+      | ComponentShareRef<T>
+      | MandatorySpec<T>
+      | Custom<T>;
+
+  /**
+   * Shared value location options.
+   */
+  export interface Options {
+
+    /**
+     * Whether to include the consumer component itself into the search.
+     *
+     * `false` by default, which means the search would start from consumer's parent.
+     */
+    readonly self?: boolean;
+
+  }
+
+  /**
+   * Shared value locator specifier.
+   *
+   * @typeParam T - Share value type.
+   */
+  export interface Spec<T> extends Options {
+
+    /**
+     * Target share.
+     */
+    readonly share?: ComponentShareRef<T>;
+
+  }
+
+  /**
+   * Mandatory shared value locator specifier.
+   *
+   * @typeParam T - Share value type.
+   */
+  export interface MandatorySpec<T> extends Spec<T> {
+
+    /**
+     * Target share.
+     */
+    readonly share: ComponentShareRef<T>;
+
+  }
+
+  /**
+   * Signature of custom shared value locator.
+   *
+   * @typeParam T - Shared value type.
+   * @typeParam consumer - Consumer component context.
+   * @typeParam options - Shared value location options.
+   *
+   * @returns An `AfterEvent` keeper of the shared value and its sharer context, if found.
+   */
+  export type Custom<T> =
+  /**
+   * @param consumer - Consumer component context.
+   * @param options - Shared value location options.
+   *
+   * @returns An `AfterEvent` keeper of the shared value and its sharer context, if found.
+   */
+      (
+          this: void,
+          consumer: ComponentContext,
+          options: Required<Options>,
+      ) => AfterEvent<[] | [T, ComponentContext]>;
+
+  /**
+   * Signature of custom shared value locator that expects a fallback share reference to be specified.
+   *
+   * @typeParam T - Shared value type.
+   */
+  export type CustomWithFallback<T> =
+  /**
+   * @param consumer - Consumer component context.
+   * @param options - Shared value location options, including fallback share reference.
+   *
+   * @returns An `AfterEvent` keeper of the shared value and its sharer context, if found.
+   */
+      (
+          this: void,
+          consumer: ComponentContext,
+          options: Required<MandatorySpec<T>>,
+      ) => AfterEvent<[] | [T, ComponentContext]>;
+
+  /**
+   * Signature of shared value locator function.
+   *
+   * Can be constructed by {@link componentShareLocator} function.
+   *
+   * @typeParam T - Shared value type.
+   */
+  export type Fn<T> =
+  /**
+   * @param consumer - Consumer component context.
+   * @param options - Shared value location options.
+   *
+   * @returns An `AfterEvent` keeper of the shared value and its sharer context, if found.
+   */
+      (
+          this: void,
+          consumer: ComponentContext,
+          defaultSpec?: Partial<Spec<T>>,
+      ) => AfterEvent<[] | [T, ComponentContext]>;
+
+}

--- a/src/share/component-share-ref.spec.ts
+++ b/src/share/component-share-ref.spec.ts
@@ -1,0 +1,28 @@
+import { noop } from '@proc7ts/primitives';
+import { ComponentShare } from './component-share';
+import { ComponentShare__symbol, isComponentShareRef } from './component-share-ref';
+
+describe('share', () => {
+  describe('isComponentShareRef', () => {
+    it('returns `true` for component share reference', () => {
+
+      const share = new ComponentShare('test');
+
+      expect(isComponentShareRef(share)).toBe(true);
+    });
+    it('returns `true` for function with `[ComponentShare__symbol]` property', () => {
+
+      const ref = noop as (() => void) & { [ComponentShare__symbol]: ComponentShare<string> };
+
+      ref[ComponentShare__symbol] = new ComponentShare('test');
+
+      expect(isComponentShareRef(ref)).toBe(true);
+    });
+    it('returns `false` for `null` value', () => {
+      expect(isComponentShareRef(null)).toBe(false);
+    });
+    it('returns `false` for string', () => {
+      expect(isComponentShareRef('some')).toBe(false);
+    });
+  });
+});

--- a/src/share/component-share-ref.ts
+++ b/src/share/component-share-ref.ts
@@ -19,3 +19,18 @@ export interface ComponentShareRef<T> {
   readonly [ComponentShare__symbol]: ComponentShare<T>;
 
 }
+
+/**
+ * Checks whether the given value is a {@link ComponentShareRef component share reference}.
+ *
+ * @typeParam T - Shared value type.
+ * @typeParam TOther - Another type the value may have.
+ * @param value - A value to check.
+ *
+ * @returns `true` if the value has a {@link ComponentShare__symbol} property, or `false` otherwise.
+ */
+export function isComponentShareRef<T, TOther>(value: ComponentShareRef<T> | TOther): value is ComponentShareRef<T> {
+  return !!value
+      && (typeof value === 'object' || typeof value === 'function')
+      && !!(value as Partial<ComponentShareRef<T>>)[ComponentShare__symbol];
+}

--- a/src/share/component-share.spec.ts
+++ b/src/share/component-share.spec.ts
@@ -327,6 +327,7 @@ describe('share', () => {
       });
       it('reports value shared by parent sharer', () => {
         share.addSharer(sharerDefContext, 'sharer-el');
+        share.addSharer(testDefContext, 'test-el');
         sharerDefContext.perComponent(shareValue(share, () => 'test'));
 
         const receiver = jest.fn();
@@ -337,6 +338,18 @@ describe('share', () => {
 
         sharerMount.connect();
         expect(receiver).toHaveBeenLastCalledWith('test', sharerMount.context);
+        expect(receiver).toHaveBeenCalledTimes(1);
+      });
+      it('reports value shared by component itself when `self` set to `true`', () => {
+        share.addSharer(sharerDefContext, 'sharer-el');
+        share.addSharer(testDefContext, 'test-el');
+        sharerDefContext.perComponent(shareValue(share, () => 'test1'));
+        testDefContext.perComponent(shareValue(share, () => 'test2'));
+
+        const receiver = jest.fn();
+
+        share.valueFor(testCtx, { self: true })(receiver);
+        expect(receiver).toHaveBeenLastCalledWith('test2', testCtx);
         expect(receiver).toHaveBeenCalledTimes(1);
       });
       it('reports value shared by mounted parent sharer', () => {

--- a/src/share/component-share.ts
+++ b/src/share/component-share.ts
@@ -16,6 +16,7 @@ import {
 } from '@proc7ts/fun-events';
 import { Supply } from '@proc7ts/primitives';
 import { BootstrapContext, ComponentContext, ComponentElement, ComponentSlot, DefinitionContext } from '@wesib/wesib';
+import { ComponentShareLocator } from './component-share-locator';
 import { ComponentShare__symbol, ComponentShareRef } from './component-share-ref';
 import { ComponentShareRegistry } from './component-share-registry.impl';
 import { ComponentShare$, ComponentShare$impl } from './component-share.impl';
@@ -120,26 +121,22 @@ export class ComponentShare<T> implements ComponentShareRef<T>, ContextUpRef<Aft
   }
 
   /**
-   * Obtains a shared value for the consuming component.
+   * Locates a shared value for the consuming component.
    *
    * Searches among parent elements for the one bound to the sharer component, then obtains the shared value from
    * the sharer's context.
    *
    * @param consumer - Consumer component context.
-   * @param self - Whether to include the consumer component itself into the search. `false` by default, which means
-   * the search would be started from iots parent.
+   * @param options - Location options.
    *
    * @returns An `AfterEvent` keeper of the shared value and its sharer context, if found.
    */
   valueFor(
       consumer: ComponentContext,
-      {
-        self,
-      }: {
-        readonly self?: boolean;
-      } = {},
+      options: ComponentShareLocator.Options = {},
   ): AfterEvent<[T, ComponentContext] | []> {
 
+    const { self } = options;
     const sharers = consumer.get(BootstrapContext).get(ComponentShareRegistry).sharers(this);
     const status = consumer.readStatus.do(
         deduplicateAfter_(

--- a/src/share/component-share.ts
+++ b/src/share/component-share.ts
@@ -15,7 +15,14 @@ import {
   translateAfter_,
 } from '@proc7ts/fun-events';
 import { Supply } from '@proc7ts/primitives';
-import { BootstrapContext, ComponentContext, ComponentElement, ComponentSlot, DefinitionContext } from '@wesib/wesib';
+import {
+  BootstrapContext,
+  ComponentContext,
+  ComponentElement,
+  ComponentSlot,
+  DefinitionContext,
+  isElement,
+} from '@wesib/wesib';
 import { ComponentShareLocator } from './component-share-locator';
 import { ComponentShare__symbol, ComponentShareRef } from './component-share-ref';
 import { ComponentShareRegistry } from './component-share-registry.impl';
@@ -230,8 +237,12 @@ export class ComponentShare<T> implements ComponentShareRef<T>, ContextUpRef<Aft
 }
 
 function parentElement(element: ComponentElement): ComponentElement | null | undefined {
-  return element.parentNode as ComponentElement | null
-      || (element.getRootNode() as ShadowRoot).host as ComponentElement | undefined; // Inside shadow DOM?
+
+  const { parentNode } = element;
+
+  return parentNode && isElement(parentNode)
+      ? parentNode
+      : (element.getRootNode() as ShadowRoot).host as ComponentElement | undefined;// Inside shadow DOM?
 }
 
 export namespace ComponentShare {

--- a/src/share/index.ts
+++ b/src/share/index.ts
@@ -1,4 +1,5 @@
 export * from './component-share';
+export * from './component-share-locator';
 export * from './component-share-ref';
 export * from './component-shareable';
 export * from './shared.decorator';


### PR DESCRIPTION
- Allow to include consumer component when search for share
- Introduce `ComponentShareLocator`
- Locate forms by their locator functions
- Add `@OnSubmit` decorator
