### PR TITLE
Shareable bodies

### DIFF
--- a/src/forms/adjacent-field.ts
+++ b/src/forms/adjacent-field.ts
@@ -66,7 +66,7 @@ export function adjacentToField<TValue, TSharer extends object = any>(
 export function adjacentToForm<TValue, TSharer extends object = any>(
     controls:
         | Field.Controls<TValue>
-        | AdjacentField.Provider<TValue, Form<unknown>, Form.Controls<unknown>, TSharer>,
+        | AdjacentField.Provider<TValue, Form<unknown>, Form.Body<unknown>, TSharer>,
     adjacentTo: ShareLocator.Mandatory<Form<unknown>> = FormShare,
 ): Field<TValue, TSharer> {
   return adjacentField(controls, adjacentTo);
@@ -152,7 +152,7 @@ function AdjacentField$provider<
 ): Field.Provider<TValue, TSharer> {
   return builder => adjacentLocator(builder.sharer).do(
       digAfter((adjacentTo?: TAdjacentTo, _sharer?): AfterEvent<[Field.Controls<TValue>?]> => adjacentTo
-          ? adjacentTo.readControls.do(
+          ? adjacentTo.read.do(
               digAfter((adjusted?: TAdjusted): AfterEvent<[Field.Controls<TValue>?]> => adjusted
                   ? afterValue(provider({
                     ...builder,

--- a/src/forms/field-name.definer.ts
+++ b/src/forms/field-name.definer.ts
@@ -30,7 +30,7 @@ export function FormName<
     TClass extends ComponentClass = Class>(
     def?: FieldNameDef,
 ): SharedForm.Definer<TForm, TModel, TElt, TClass> {
-  return FormUnitName<TForm, TModel, Form.Controls<TModel, TElt>, TClass>(def);
+  return FormUnitName<TForm, TModel, Form.Body<TModel, TElt>, TClass>(def);
 }
 
 /**
@@ -92,10 +92,10 @@ function FormUnitName<
           setup.whenComponent(context => {
             afterAll({
               unit: context.get(share).do(
-                  digAfter_(unit => unit ? unit.readControls : afterThe<[TControls?]>()),
+                  digAfter_(unit => unit ? unit.read : afterThe<[TControls?]>()),
               ),
               form: locateForm(context).do(
-                  digAfter_((form?, _sharer?) => form ? form.readControls : afterThe<[Form.Controls<any>?]>()),
+                  digAfter_((form?, _sharer?) => form ? form.read : afterThe<[Form.Body<any>?]>()),
               ),
             }).do(
                 consumeEvents(({ unit: [field], form: [form] }): Supply | undefined => {

--- a/src/forms/field.spec.ts
+++ b/src/forms/field.spec.ts
@@ -43,7 +43,7 @@ describe('forms', () => {
 
         field[Contextual__symbol](context);
 
-        expect(field.control).toBe(control1);
+        expect(field.body).toEqual({ field, control: control1 });
         expect(control1.supply.isOff).toBe(false);
 
         controls.it = { control: control1 };

--- a/src/forms/form-unit.ts
+++ b/src/forms/form-unit.ts
@@ -1,6 +1,5 @@
 import { InControl } from '@frontmeans/input-aspects';
 import { Contextual__symbol } from '@proc7ts/context-values';
-import { AfterEvent, AfterEvent__symbol } from '@proc7ts/fun-events';
 import { noop } from '@proc7ts/primitives';
 import { ComponentContext } from '@wesib/wesib';
 import { Shareable } from '../shares';
@@ -32,22 +31,15 @@ export abstract class FormUnit<
   }
 
   /**
-   * An `AfterEvent` keeper of form unit controls.
-   */
-  get readControls(): AfterEvent<[TControls?]> {
-    return this[AfterEvent__symbol]();
-  }
-
-  /**
    * Input control of the field, if present.
    */
   get control(): InControl<TValue> | undefined {
-    return this.internals?.control;
+    return this.body?.control;
   }
 
   [Contextual__symbol](sharer: ComponentContext): this {
     super[Contextual__symbol](sharer);
-    this.readControls(noop).needs(sharer); // Create controls eagerly.
+    this.read(noop).needs(sharer); // Create controls eagerly.
     return this;
   }
 

--- a/src/forms/form.ts
+++ b/src/forms/form.ts
@@ -242,7 +242,12 @@ export namespace Form {
       TModel = any,
       TElt extends HTMLElement = HTMLElement,
       TSharer extends object = any>
-      extends Form<TModel, TElt, TSharer>, Form.Body<TModel, TElt> {
+      extends Form<TModel, TElt, TSharer> {
+
+    /**
+     * Form body.
+     */
+    readonly body: Body<TModel, TElt, TSharer>;
 
     /**
      * Submittable form input control.

--- a/src/forms/form.ts
+++ b/src/forms/form.ts
@@ -307,7 +307,12 @@ export namespace Form {
       TModel,
       TElt extends HTMLElement = HTMLElement,
       TSharer extends object = any,
-      > extends Controls<TModel, TElt> {
+      > extends FormUnit.Controls<TModel> {
+
+    /**
+     * A form the controls belong to.
+     */
+    readonly form: Form<TModel, TElt, TSharer>;
 
     /**
      * Submittable form input control.
@@ -321,11 +326,6 @@ export namespace Form {
      * element issuing a `submit` event.
      */
     readonly element: InFormElement<TElt>;
-
-    /**
-     * A form the controls belong to.
-     */
-    readonly form: Form<TModel, TElt, TSharer>;
 
   }
 

--- a/src/forms/on-submit.decorator.ts
+++ b/src/forms/on-submit.decorator.ts
@@ -9,7 +9,8 @@ import { FormShare } from './form.share';
 /**
  * Creates a decorator for component method to call on input form submit.
  *
- * The decorated method accepts a {@link Form.Whole whole form} about to be submitted, and a submit event as parameters.
+ * The decorated method accepts {@link Form.Body controls of the form} about to be submitted, and a submit event as
+ * parameters.
  *
  * @typeParam TModel - Submitted model type.
  * @typeParam TElt - A type of HTML form element.
@@ -20,7 +21,7 @@ import { FormShare } from './form.share';
  */
 export function OnSubmit<TModel = any, TElt extends HTMLElement = HTMLElement, T extends ComponentClass = Class>(
     def: OnSubmitDef<TModel, TElt> = {},
-): ComponentPropertyDecorator<(form: Form.Whole<TModel, TElt, InstanceType<T>>, event: Event) => void, T> {
+): ComponentPropertyDecorator<(form: Form.Body<TModel, TElt, InstanceType<T>>, event: Event) => void, T> {
 
   const { form: formRef = FormShare, cancel = true } = def;
   const locateForm = shareLocator(formRef, { share: FormShare, local: 'too' });
@@ -36,13 +37,13 @@ export function OnSubmit<TModel = any, TElt extends HTMLElement = HTMLElement, T
             locateForm(context).do(
                 consumeEvents((form?: Form<TModel, TElt>, _sharer?: ComponentContext) => {
 
-                  const ready = form?.asWhole();
+                  const controls = form?.body;
 
-                  if (!ready) {
+                  if (!controls) {
                     return;
                   }
 
-                  let onSubmit = ready.element.events.on('submit');
+                  let onSubmit = controls.element.events.on('submit');
 
                   if (cancel) {
                     onSubmit = onSubmit.do(
@@ -51,7 +52,7 @@ export function OnSubmit<TModel = any, TElt extends HTMLElement = HTMLElement, T
                   }
 
                   return onSubmit(
-                      event => get(component).call(component, ready, event),
+                      event => get(component).call(component, controls, event),
                   );
                 }),
             ).needs(context);

--- a/src/forms/on-submit.decorator.ts
+++ b/src/forms/on-submit.decorator.ts
@@ -9,7 +9,7 @@ import { FormShare } from './form.share';
 /**
  * Creates a decorator for component method to call on input form submit.
  *
- * The decorated method accepts {@link Form.Body controls of the form} about to be submitted, and a submit event as
+ * The decorated method accepts a {@link Form.Body body of the form} about to be submitted, and a submit event as
  * parameters.
  *
  * @typeParam TModel - Submitted model type.

--- a/src/forms/shared-form.decorator.spec.ts
+++ b/src/forms/shared-form.decorator.spec.ts
@@ -44,21 +44,22 @@ describe('forms', () => {
 
       const element = new (await testElement(TestComponent))();
       const context = await ComponentSlot.of(element).whenReady;
-      const form = await context.get(FormShare);
+      const form = (await context.get(FormShare))!;
 
       expect(form).toBeInstanceOf(Form);
-      expect(form?.control).toBeUndefined();
-      expect(form?.element).toBeUndefined();
+      expect(form.control).toBeUndefined();
+      expect(form.element).toBeUndefined();
 
       hasControls.it = true;
-      expect(form?.control?.aspect(Form)).toBe(form);
-      expect(form?.element).toBeInstanceOf(InElement);
+      expect(form.control?.aspect(Form)).toBe(form);
+      expect(form.element).toBeInstanceOf(InElement);
 
-      const controls = await form?.readControls;
+      const body = await form?.read;
 
-      expect(controls).toEqual({
-        control: form?.control,
-        element: form?.element,
+      expect(body).toEqual({
+        form,
+        control: form.control,
+        element: form.element,
       });
     });
   });

--- a/src/forms/shared-form.decorator.ts
+++ b/src/forms/shared-form.decorator.ts
@@ -56,7 +56,7 @@ export function SharedForm<
     ...define: SharedForm.Definer<TForm, TModel, TElt, TClass>[]
 ): ShareDecorator<TForm, TClass> {
   if (typeof defOrDefiner === 'function') {
-    return SharedFormUnit<TForm, TModel, Form.Controls<TModel, TElt>, TClass>(
+    return SharedFormUnit<TForm, TModel, Form.Body<TModel, TElt>, TClass>(
         FormShare as ShareRef<any> as ShareRef<TForm>,
         defOrDefiner,
         ...define,
@@ -65,7 +65,7 @@ export function SharedForm<
 
   const { share = FormShare as ShareRef<any> as ShareRef<TForm> } = defOrDefiner;
 
-  return SharedFormUnit<TForm, TModel, Form.Controls<TModel, TElt>, TClass>(share, ...define);
+  return SharedFormUnit<TForm, TModel, Form.Body<TModel, TElt>, TClass>(share, ...define);
 }
 
 /**
@@ -105,7 +105,7 @@ export namespace SharedForm {
       TModel = Form.ModelType<TForm>,
       TElt extends HTMLElement = Form.ElementType<TForm>,
       TClass extends ComponentClass = Class>
-      extends SharedFormUnit.Descriptor<TForm, TModel, Form.Controls<TModel, TElt>, TClass> {
+      extends SharedFormUnit.Descriptor<TForm, TModel, Form.Body<TModel, TElt>, TClass> {
 
     /**
      * Target form share instance.
@@ -152,6 +152,6 @@ export namespace SharedForm {
       TModel = Form.ModelType<TForm>,
       TElt extends HTMLElement = Form.ElementType<TForm>,
       TClass extends ComponentClass = Class> =
-      SharedFormUnit.Definition<TForm, TModel, Form.Controls<TModel, TElt>, TClass>;
+      SharedFormUnit.Definition<TForm, TModel, Form.Body<TModel, TElt>, TClass>;
 
 }

--- a/src/shares/shared.decorator.spec.ts
+++ b/src/shares/shared.decorator.spec.ts
@@ -1,5 +1,5 @@
 import { SingleContextKey } from '@proc7ts/context-values';
-import { AfterEvent, afterThe, trackValue } from '@proc7ts/fun-events';
+import { AfterEvent, afterSupplied, afterThe, trackValue } from '@proc7ts/fun-events';
 import {
   BootstrapContext,
   Component,
@@ -110,10 +110,6 @@ describe('shares', () => {
 
       class TestShareable extends Shareable<string> {
 
-        get it(): string {
-          return this.internals;
-        }
-
       }
 
       @Component({ extend: { type: Object } })
@@ -127,10 +123,11 @@ describe('shares', () => {
       const element = new (await testElement(TestComponent))();
       const context = await ComponentSlot.of(element).whenReady;
       const shared = context.get(share2);
-      const shareable = await shared;
+      const shareable = (await shared)!;
 
       expect(shareable).toBeInstanceOf(TestShareable);
-      expect(shareable?.it).toBe('test');
+      expect(shareable.body).toBe('test');
+      expect(await afterSupplied(shareable)).toBe('test');
     });
     it('applies share extension', async () => {
 


### PR DESCRIPTION
- `Shareable`: Rename "internals" to "body".
- Make `Form` and `Field` bodies contain instances to their owners
  along with input controls.
